### PR TITLE
fixing up failing push docker build

### DIFF
--- a/mldock/__version__.py
+++ b/mldock/__version__.py
@@ -1,2 +1,2 @@
 """CLI and Package version"""
-__version__ = "0.8.18"
+__version__ = "0.8.19"

--- a/mldock/command/registry.py
+++ b/mldock/command/registry.py
@@ -92,7 +92,8 @@ def push(obj, project_directory, provider, **kwargs):
     dockerfile_path = os.path.join(
         project_directory,
         mldock_config.get("mldock_module_dir", "src"),
-        container_dir
+        container_dir,
+        "Dockerfile"
     )
     requirements_file_path = os.path.join(
         project_directory,


### PR DESCRIPTION
- dockerbuild failing because change in api/build expecting dockerfile fullpath to file.
- currently docker daemon errors are not passed up to python. Potentially checking logs for error messages could be done in future and re-raising.