### PR TITLE
Bugfix/requirements default points to src dir

### DIFF
--- a/mldock/__version__.py
+++ b/mldock/__version__.py
@@ -1,2 +1,2 @@
 """CLI and Package version"""
-__version__ = "0.8.21"
+__version__ = "0.8.22"

--- a/mldock/config_managers/container.py
+++ b/mldock/config_managers/container.py
@@ -25,7 +25,7 @@ class MLDockConfigManager(BaseConfigManager):
     config = {
         "image_name": None,
         "template": "generic",
-        "requirements_dir": "src",
+        "requirements_dir": "src/requirements.txt",
         "mldock_module_dir": "src",
         "container_dir": "container",
         "data": [],


### PR DESCRIPTION
default requirements pointing to directory error. Points to `<container-project>/src/`.

fix reverts to the `<container-project>/src/requirements.txt`.