### PR TITLE
change container => project command group

### DIFF
--- a/mldock/__main__.py
+++ b/mldock/__main__.py
@@ -7,7 +7,7 @@ import click
 
 from mldock.__version__ import __version__
 from mldock.__init__ import MLDOCK_LOGO
-from mldock.command.container import container
+from mldock.command.project import project
 from mldock.command.configure import configure
 from mldock.command.local import local
 from mldock.command.registry import registry
@@ -49,7 +49,7 @@ def add_commands(cli_group: click.group):
         cli (click.group)
     """
     cli_group.add_command(configure)
-    cli_group.add_command(container)
+    cli_group.add_command(project)
     cli_group.add_command(local)
     cli_group.add_command(registry)
     cli_group.add_command(templates)

--- a/mldock/command/datasets.py
+++ b/mldock/command/datasets.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 
 from mldock.config_managers.cli import InputDataConfigManager, CliConfigureManager
-from mldock.config_managers.container import MLDockConfigManager
+from mldock.config_managers.project import MLDockConfigManager
 from mldock.terminal import ProgressLogger
 from mldock.platform_helpers.mldock.storage.pyarrow import (
     upload_assets,

--- a/mldock/command/local.py
+++ b/mldock/command/local.py
@@ -17,7 +17,7 @@ from mldock.terminal import (
     pretty_build_logs,
 )
 from mldock.platform_helpers.mldock import utils as mldock_utils
-from mldock.config_managers.container import MLDockConfigManager
+from mldock.config_managers.project import MLDockConfigManager
 from mldock.api.local import (
     search_mldock_containers,
     docker_build,

--- a/mldock/command/models.py
+++ b/mldock/command/models.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 
 from mldock.config_managers.cli import ModelConfigManager, CliConfigureManager
-from mldock.config_managers.container import MLDockConfigManager
+from mldock.config_managers.project import MLDockConfigManager
 from mldock.terminal import ProgressLogger
 from mldock.platform_helpers.mldock.storage.pyarrow import (
     upload_assets,

--- a/mldock/command/project.py
+++ b/mldock/command/project.py
@@ -6,7 +6,7 @@ import logging
 import click
 
 from mldock.config_managers.core import WorkingDirectoryManager
-from mldock.config_managers.container import MLDockConfigManager
+from mldock.config_managers.project import MLDockConfigManager
 from mldock.platform_helpers import utils
 from mldock.config_managers.cli import (
     PackageConfigManager,
@@ -31,9 +31,9 @@ def reset_terminal():
 
 
 @click.group()
-def container():
+def project():
     """
-    Commands to create, update and manage container projects and templates.
+    Commands to create, update and manage project projects and templates.
     """
 
 
@@ -42,7 +42,7 @@ def container():
     "--project_directory",
     "--dir",
     "-d",
-    help="mldock container project.",
+    help="mldock project project.",
     required=True,
     type=click.Path(
         exists=False,
@@ -58,7 +58,7 @@ def container():
 @click.option(
     "--no-prompt",
     is_flag=True,
-    help="Do not prompt user, instead use the mldock config to initialize the container.",
+    help="Do not prompt user, instead use the mldock config to initialize the project.",
 )
 @click.option(
     "--container-only", is_flag=True, help="Only inject new container assets."
@@ -66,7 +66,7 @@ def container():
 @click.option(
     "--template",
     default=None,
-    help="Directory containing mldock supported container to use to initialize the container.",
+    help="Directory containing mldock supported project template to use to initialize the new project.",
 )
 @click.option("--requirements", default=None, help="path to requirements file.")
 @click.option(
@@ -281,7 +281,7 @@ def init(obj, project_directory, **kwargs):
             click.echo(click.style(state["name"], bg="blue"), nl=True)
             click.echo(click.style(state["message"], fg="white"), nl=True)
 
-        logger.info("\nlocal container volume is ready! ヽ(´▽`)/")
+        logger.info("\nlocal project volume is ready! ヽ(´▽`)/")
     except Exception as exception:
         logger.error(exception)
         raise
@@ -308,7 +308,7 @@ def init(obj, project_directory, **kwargs):
 @click.pass_obj
 def update(obj, project_directory):
     """
-    Command to update mldock container.
+    Command to update mldock project.
     """
     reset_terminal()
     try:
@@ -377,7 +377,7 @@ def update(obj, project_directory):
             click.echo(click.style(state["name"], bg="blue"), nl=True)
             click.echo(click.style(state["message"], fg="white"), nl=True)
 
-        logger.info("\nlocal container was updated! ヽ(´▽`)/")
+        logger.info("\nlocal project was updated! ヽ(´▽`)/")
     except Exception as exception:
         logger.error(exception)
         raise
@@ -403,7 +403,7 @@ def update(obj, project_directory):
 )
 def summary(project_directory):
     """
-    Command to show summary for mldock container
+    Command to show summary for mldock container project
     """
     try:
         mldock_manager = MLDockConfigManager(
@@ -432,4 +432,4 @@ def add_commands(cli_group: click.group):
     cli_group.add_command(summary)
 
 
-add_commands(container)
+add_commands(project)

--- a/mldock/command/registry.py
+++ b/mldock/command/registry.py
@@ -6,7 +6,7 @@ import click
 from mldock.platform_helpers.docker.auth import login_and_authenticate
 from mldock.api.local import docker_build
 from mldock.api.registry import push_image_to_repository, pull_image_from_repository
-from mldock.config_managers.container import MLDockConfigManager
+from mldock.config_managers.project import MLDockConfigManager
 from mldock.terminal import ProgressLogger, pretty_build_logs
 
 click.disable_unicode_literals_warning = True

--- a/mldock/config_managers/project.py
+++ b/mldock/config_managers/project.py
@@ -1,5 +1,5 @@
 """
-    Project Container Config manager
+    Container Project Config manager
 
     Config Managers that create and update the container project config.
     Currently supported:
@@ -65,7 +65,7 @@ class MLDockConfigManager(BaseConfigManager):
                 logger.error(
                     (
                         "No MLDOCK container project found with "
-                        "dir = '{CONTAINER_DIR}/'. Re-run `mldock container init` "
+                        "dir = '{CONTAINER_DIR}/'. Re-run `mldock project init` "
                         "and Confirm 'yes' to create.".format(
                             CONTAINER_DIR=Path(file_name).parents[0]
                         )
@@ -96,9 +96,9 @@ class MLDockConfigManager(BaseConfigManager):
         self.config.update({"image_name": image_name})
 
     def ask_for_template_name(self):
-        """prompt user for container template name"""
+        """prompt user for container project template name"""
 
-        click.secho("Set container template name", bg="blue", nl=True)
+        click.secho("Set container project template name", bg="blue", nl=True)
         # would be awesome to fetch this from the template dir
         options = self.available_templates
 

--- a/tests/command/test_local.py
+++ b/tests/command/test_local.py
@@ -32,7 +32,7 @@ class TestLocalCommands:
                 args=['configure', 'local'],
                 input='2\n\n'
             )
-            _ = runner.invoke(cli=cli, args=['container', 'init', '--dir', tmp_dir, '--no-prompt'])
+            _ = runner.invoke(cli=cli, args=['project', 'init', '--dir', tmp_dir, '--no-prompt'])
 
             result = runner.invoke(cli=cli, args=['local', 'build', '--dir', tmp_dir])
 
@@ -62,7 +62,7 @@ class TestLocalCommands:
                 args=['configure', 'local'],
                 input='2\n\n'
             )
-            _ = runner.invoke(cli=cli, args=['container', 'init', '--dir', tmp_dir, '--no-prompt'])
+            _ = runner.invoke(cli=cli, args=['project', 'init', '--dir', tmp_dir, '--no-prompt'])
 
             _ = runner.invoke(cli=cli, args=['local', 'build', '--dir', tmp_dir])
 

--- a/tests/command/test_project.py
+++ b/tests/command/test_project.py
@@ -1,4 +1,4 @@
-"""Test Container commands"""
+"""Test Project commands"""
 import os
 from pathlib import Path
 from mock import patch
@@ -22,7 +22,7 @@ def mldock_config_aws():
         'template': 'generic'
     }
 
-class TestContainerCommands:
+class TestProjectCommands:
 
     @staticmethod
     def test_command_init_w_no_prompt_runs_successfully():
@@ -47,7 +47,7 @@ class TestContainerCommands:
                 args=['configure', 'local'],
                 input='2\n\n'
             )
-            result = runner.invoke(cli=cli, args=['container', 'init', '--dir', mldock_project, '--no-prompt'])
+            result = runner.invoke(cli=cli, args=['project', 'init', '--dir', mldock_project, '--no-prompt'])
 
         assert result.exit_code == 0, result.output
 
@@ -75,7 +75,7 @@ class TestContainerCommands:
             )
             result = runner.invoke(
                 cli=cli,
-                args=['container', 'init', '--dir', mldock_project],
+                args=['project', 'init', '--dir', mldock_project],
                 input='my_app\ngeneric\nsrc\ncontainer\nrequirements.txt\n\n\n\n\n'
             )
 
@@ -103,7 +103,7 @@ class TestContainerCommands:
             )
             result = runner.invoke(
                 cli=cli,
-                args=['container', 'init', '--dir', mldock_project, '--template', 'generic', '--no-prompt'],
+                args=['project', 'init', '--dir', mldock_project, '--template', 'generic', '--no-prompt'],
                 input='yes\n'
             )
 
@@ -143,7 +143,7 @@ class TestContainerCommands:
             )
             result = runner.invoke(
                 cli=cli,
-                args=['container', 'init', '--dir', tmp_dir, '--template', 'generic', '--no-prompt'],
+                args=['project', 'init', '--dir', tmp_dir, '--template', 'generic', '--no-prompt'],
                 input='\n'
             )
 
@@ -172,7 +172,7 @@ class TestContainerCommands:
             result = runner.invoke(
                 cli=cli,
                 args=[
-                    'container', 'init',
+                    'project', 'init',
                     '--dir', mldock_project,
                     '--template', 'generic',
                     '--no-prompt',


### PR DESCRIPTION
Container commands renamed to "project" commands as this lines up more with the use case, creating container projects.
Since it is possible to have other aspects to a project, namely scripts and code and frameworks like dvc.
- resolves #86 
