### PR TITLE
add retagging of images on push and pull

### DIFF
--- a/mldock/api/registry.py
+++ b/mldock/api/registry.py
@@ -130,6 +130,11 @@ def push_image_to_repository(image_repository: str, auth_config: dict, tag="late
         states = stateful_log_emitter(line=line, states=states, status_tag="Pushing")
     return states
 
+def tag_image(current_repository, new_repository, new_tag):
+    client = docker.from_env()
+    client.api.tag(current_repository, repository=new_repository, tag=new_tag, force=False)
+    return f"{new_repository}:{new_tag}"
+
 
 def pull_image_from_repository(image_repository: str, auth_config: dict, tag="latest"):
     """
@@ -150,4 +155,6 @@ def pull_image_from_repository(image_repository: str, auth_config: dict, tag="la
         states = stateful_log_emitter(
             line=line, states=states, status_tag="Downloading"
         )
+    
     return states
+

--- a/mldock/command/registry.py
+++ b/mldock/command/registry.py
@@ -136,7 +136,7 @@ def push(obj, project_directory, provider, **kwargs):
                 spinner.start()
 
     elif image is not None:
-        print(f"tagging image: {image_repository}:{tag} => {local_image_name}:{tag}")
+        logger.info(f"tagging image: {image_repository}:{tag} => {local_image_name}:{tag}")
         tag_image(f"{image}:{tag}", local_image_name, tag)
 
     # Push image to cloud repository
@@ -257,8 +257,8 @@ def pull(obj, project_directory, provider, **kwargs):
         logger.info(obj["logo"])
         spinner.start()
 
-        # tag as new image
-    print(f"tagging image: {image_repository}:{tag} => {local_image_name}:{tag}")
+    # tag as new image
+    logger.info(f"tagging image: {image_repository}:{tag} => {local_image_name}:{tag}")
     tag_image(f"{image_repository}:{tag}", local_image_name, tag)
 
 


### PR DESCRIPTION
- Resolves #96 (retag pulled images)
- Resolves #79 (allow tagging of a locally prebuilt image which then gets pushed to registry)

Simply adds a docker tag step / option in both cases. 